### PR TITLE
inherit Verdict from BaseException and handle it

### DIFF
--- a/gornilo/actions.py
+++ b/gornilo/actions.py
@@ -176,6 +176,8 @@ class Checker:
             if type(result) != Verdict:
                 print(f"Checker function returned not Verdict value, we need to fix it!", file=sys.stderr)
                 result = Verdict.CHECKER_ERROR("")
+        except Verdict as verdict:
+            result = verdict
         except Exception as e:
             print(f"Checker caught an error: {e},\n {format_exc()}", file=sys.stderr)
             result = Verdict.CHECKER_ERROR("")

--- a/gornilo/models/verdict/verdict.py
+++ b/gornilo/models/verdict/verdict.py
@@ -4,7 +4,7 @@ import json
 
 
 # noinspection PyPep8Naming
-class Verdict:
+class Verdict(BaseException):
     def __init__(self, code: int, public_message: str = ''):
         self._code: int = code
         self._public_message: str = public_message


### PR DESCRIPTION
Added support for raising Verdict as an exception

We use `BaseException` in order to bypass possible `except Exception` in checkers:

```python
try:
    ...  # some checking code
    raise Verdict.CORRUPT(...)
except Exception as e:
    return Verdict.MUMBLE(...)
```